### PR TITLE
Minor CSS updates for Django 3.2

### DIFF
--- a/cronfield/static/cronfield/crontab_widget.css
+++ b/cronfield/static/cronfield/crontab_widget.css
@@ -5,29 +5,32 @@
 .cc_wrapper .cc_element {
 	padding: 20px;
 	float: left;
-	width: 110px;
+	width: 160px;
 }
 
 .cc_wrapper .cc_element select {
 	width: 100%;
+	margin-bottom: 2px;
 	background: white;
 	color: black;
 }
 
 .cc_wrapper .cc_element .button {
-	width: 50%;
+	width: 76px;
 	text-align: center;
 	cursor: pointer;
+	margin: 2px;
 }
 
 .cc_wrapper .cc_element .fleft {
-	width: 50px;
+	width: 75px;
 	padding-right: 0px;
-	margin-right: 0px;
+	margin: 2px;
 	float: left;
 }
 
 .cc_wrapper .cc_element .fright {
 	width: 50px;
+	margin: 2px;
 	float: right;
 }


### PR DESCRIPTION
I have made some small CSS changes in order to adapt the appearance of the widget for Django 3.2. Here is a comparison of the output:

![cronfield-old](https://github.com/knaperek/django-cronfield/assets/25832824/581d5c36-9894-42b4-b02b-f7165106ce56)

![cronfield-new](https://github.com/knaperek/django-cronfield/assets/25832824/50df81e6-11a5-4838-8e8e-80a08fb65603)